### PR TITLE
Fixing createRest method

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,13 +68,15 @@ This extension for Keystone is intended to create a REST API very easy. Also is 
 
     // Make sure keystone is initialized and started before
     // calling createRest
+
     keystone.init(config);
-    keystone.start();
 
     // Add routes with Keystone
     keystoneRestApi.createRest(keystone, {
-		apiRoot: '/api/v1/'
+		apiRoot: '/api/'
 	});
+
+    keystone.start();
 	
 	// Create Documentation and write it to a file
 	fs.writeFileSync('api.md', keystoneRestApi.apiDocs(), 'UTF-8');

--- a/index.js
+++ b/index.js
@@ -808,7 +808,9 @@ function KeystoneRest() {
 		// Get and register the models
 		_registerRestModels(keystone);
 
+		const setCurrentRoutes = keystone.get('routes')
 		keystone.set('routes', app => {
+			setCurrentRoutes(app)
 			_.each(self.routes, function (route) {
 				app[route.method](route.route, route.middleware, route.handler);
 			});

--- a/index.js
+++ b/index.js
@@ -369,9 +369,10 @@ function KeystoneRest() {
 					if (err) {
 						return _sendError(err, req, res, next);
 					}
-
-					var query = Model.find(criteria).skip(req.query.skip)
-						.limit(req.query.limit)
+					var limit = req.query.limit ? Number.parseInt(req.query.limit) : undefined;
+					var skip = req.query.skip ? Number.parseInt(req.query.skip) : undefined;
+					var query = Model.find(criteria).skip(skip)
+						.limit(limit)
 						.sort(req.query.sort)
 						.select(querySelect || selected);
 

--- a/index.js
+++ b/index.js
@@ -808,8 +808,10 @@ function KeystoneRest() {
 		// Get and register the models
 		_registerRestModels(keystone);
 
-		_.each(self.routes, function (route) {
-			keystone.app[route.method](route.route, route.middleware, route.handler);
+		keystone.set('routes', app => {
+			_.each(self.routes, function (route) {
+				app[route.method](route.route, route.middleware, route.handler);
+			});
 		});
 	};
 


### PR DESCRIPTION
I've noticed that the example code does not work on current versions of keyston-classic.
I think this is related to this repo being outdated on new keystone-classic versions and therefore I've created this fork that fixes this issue by:

- Updating `createRest` by using  `keystone.set` to set up the routes
- Updating `README.md` moving the invocation before the `keystone.start`

Hoping this approach works